### PR TITLE
Minor fixes to logging and spelling.

### DIFF
--- a/app/src/main/java/com/aricneto/twistytimer/activity/MainActivity.java
+++ b/app/src/main/java/com/aricneto/twistytimer/activity/MainActivity.java
@@ -89,8 +89,6 @@ public class MainActivity extends AppCompatActivity implements BillingProcessor.
     private static final int REQUEST_ABOUT             = 23;
     private static final int STORAGE_PERMISSION_CODE   = 11;
 
-    private static final String OPEN_EXPORT_IMPORT_DIALOG = "open_export_import_dialog";
-
     final MainActivity mainActivity = this;
 
     BillingProcessor bp;
@@ -109,7 +107,6 @@ public class MainActivity extends AppCompatActivity implements BillingProcessor.
     private DatabaseHandler handler;
 
     private boolean goBack = false;
-    private boolean openExportImportDialog;
 
     BroadcastReceiver mReceiver = new BroadcastReceiver() {
         @Override
@@ -151,12 +148,6 @@ public class MainActivity extends AppCompatActivity implements BillingProcessor.
                 .beginTransaction()
                 .replace(R.id.main_activity_container, TimerFragmentMain.newInstance(), "fragment_main")
                 .commit();
-            try {
-                openExportImportDialog = savedInstanceState.getBoolean(OPEN_EXPORT_IMPORT_DIALOG);
-            } catch (Exception e) {
-                e.printStackTrace();
-                openExportImportDialog = false;
-            }
         }
 
         handleDrawer(savedInstanceState);
@@ -167,12 +158,6 @@ public class MainActivity extends AppCompatActivity implements BillingProcessor.
     @Override
     protected void onResume() {
         super.onResume();
-        if (openExportImportDialog) {
-            ExportImportDialog exportImportDialog = ExportImportDialog.newInstance();
-            exportImportDialog.setDialogInterface(mainActivity);
-            exportImportDialog.show(fragmentManager, "exportImport_dialog");
-            openExportImportDialog = false;
-        }
     }
 
     private void handleDrawer(Bundle savedInstanceState) {
@@ -597,8 +582,8 @@ public class MainActivity extends AppCompatActivity implements BillingProcessor.
 
                 if (isBackup) {
                     Cursor cursor = handler.getAllSolves();
-                    publishProgress(0, cursor.getCount());
                     if (cursor != null) {
+                        publishProgress(0, cursor.getCount());
                         out.write(csvHeader);
                         while (cursor.moveToNext()) {
                             csvValues = "\"" + cursor.getString(1) + "\";";
@@ -618,8 +603,8 @@ public class MainActivity extends AppCompatActivity implements BillingProcessor.
                     returnCode = true;
                 } else {
                     Cursor cursor = handler.getAllSolvesFrom(exportImportPuzzle, exportImportCategory);
-                    publishProgress(0, cursor.getCount());
                     if (cursor != null) {
+                        publishProgress(0, cursor.getCount());
                         while (cursor.moveToNext()) {
                             csvValues = "\"" + PuzzleUtils.convertTimeToString(cursor.getInt(3)) + "\";";
                             csvValues += "\"" + cursor.getString(5) + "\";";
@@ -731,7 +716,7 @@ public class MainActivity extends AppCompatActivity implements BillingProcessor.
                                 int time = PuzzleUtils.parseTime(line[0]);
                                 String scramble = "";
                                 long date = DateTime.now().getMillis();
-                                ;
+
                                 if (line.length >= 2) {
                                     scramble = line[1];
                                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,7 +142,7 @@
     <string name="sent_to_session">Moved to session</string>
     <string name="sent_to_history">Moved to history</string>
     <string name="move_solves_to_history">Move solves to history?</string>
-    <string name="move_solves_to_history_content">You\'ll be able to acess them by tapping the history switch</string>
+    <string name="move_solves_to_history_content">You\'ll be able to access them by tapping the history switch</string>
     <string name="action_move">Move</string>
     <string name="invalid_time">Invalid time</string>
     <string name="pagerEnabledTitle">Allow swiping between tabs</string>


### PR DESCRIPTION
Fixed spelling of "access" (was "acess") in "strings.xml".

Removed code that dereferenced "savedInstanceState" in an "if" statement
that already checked the value was always null. The code caused a stack
trace for a "NullPointerException" to be logged every time. The value of
the "openExportImportDialog" field was always "false", so the code in
"onResume" that depended on it being "true" was also removed.
