### PR TITLE
Support for "DNF" in text import/export and improved import speed.

### DIFF
--- a/app/src/main/java/com/aricneto/twistytimer/activity/MainActivity.java
+++ b/app/src/main/java/com/aricneto/twistytimer/activity/MainActivity.java
@@ -65,10 +65,13 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
 
 import butterknife.ButterKnife;
+
+import static com.aricneto.twistytimer.database.DatabaseHandler.*;
 
 
 public class MainActivity extends AppCompatActivity implements BillingProcessor.IBillingHandler,
@@ -585,52 +588,67 @@ public class MainActivity extends AppCompatActivity implements BillingProcessor.
 
         @Override
         protected Boolean doInBackground(Void... voids) {
-            Boolean returnCode = false;
+            File outFile = new File(fileDir, outFileName);
+            Boolean returnCode;
             int exports = 0;
-            String csvHeader = "Puzzle,Category,Time(millis),Date(millis),Scramble,Penalty,Comment\n";
-            String csvValues = "";
 
             try {
-                File outFile = new File(fileDir, outFileName);
-                FileWriter fileWriter = new FileWriter(outFile);
-                BufferedWriter out = new BufferedWriter(fileWriter);
+                final Writer out = new BufferedWriter(new FileWriter(outFile));
 
                 if (isBackup) {
+                    String csvHeader
+                            = "Puzzle,Category,Time(millis),Date(millis),Scramble,Penalty,Comment\n";
                     Cursor cursor = handler.getAllSolves();
-                    publishProgress(0, cursor.getCount());
-                    if (cursor != null) {
+
+                    try {
+                        publishProgress(0, cursor.getCount());
                         out.write(csvHeader);
+
                         while (cursor.moveToNext()) {
-                            csvValues = "\"" + cursor.getString(1) + "\";";
-                            csvValues += "\"" + cursor.getString(2) + "\";";
-                            csvValues += "\"" + cursor.getInt(3) + "\";";
-                            csvValues += "\"" + cursor.getLong(4) + "\";";
-                            csvValues += "\"" + cursor.getString(5) + "\";";
-                            csvValues += "\"" + cursor.getInt(6) + "\";";
-                            csvValues += "\"" + cursor.getString(7) + "\"\n";
-                            out.write(csvValues);
+                            out.write('"' + cursor.getString(IDX_TYPE)
+                                    + "\";\"" + cursor.getString(IDX_SUBTYPE)
+                                    + "\";\"" + cursor.getInt(IDX_TIME)
+                                    + "\";\"" + cursor.getLong(IDX_DATE)
+                                    + "\";\"" + cursor.getString(IDX_SCRAMBLE)
+                                    + "\";\"" + cursor.getInt(IDX_PENALTY)
+                                    + "\";\"" + cursor.getString(IDX_COMMENT)
+                                    + "\"\n");
                             exports++;
                             publishProgress(exports);
                         }
+                    } finally {
                         cursor.close();
+                        out.close();
                     }
-                    out.close();
                     returnCode = true;
                 } else {
                     Cursor cursor = handler.getAllSolvesFrom(exportImportPuzzle, exportImportCategory);
-                    publishProgress(0, cursor.getCount());
-                    if (cursor != null) {
+
+                    try {
+                        publishProgress(0, cursor.getCount());
+
                         while (cursor.moveToNext()) {
-                            csvValues = "\"" + PuzzleUtils.convertTimeToString(cursor.getInt(3)) + "\";";
-                            csvValues += "\"" + cursor.getString(5) + "\";";
-                            csvValues += "\"" + new DateTime(cursor.getLong(4)).toString() + "\"\n";
+                            String csvValues
+                                    = '"' + PuzzleUtils.convertTimeToString(cursor.getInt(IDX_TIME))
+                                    + "\";\"" + cursor.getString(IDX_SCRAMBLE)
+                                    + "\";\"" + new DateTime(cursor.getLong(IDX_DATE)).toString()
+                                    + '"';
+
+                            // Add optional "DNF" in fourth field.
+                            if (cursor.getInt(IDX_PENALTY) == PuzzleUtils.PENALTY_DNF) {
+                                csvValues += ";\"DNF\"";
+                            }
+
+                            csvValues += '\n';
+
                             out.write(csvValues);
                             exports++;
                             publishProgress(exports);
                         }
+                    } finally {
                         cursor.close();
+                        out.close();
                     }
-                    out.close();
                     returnCode = true;
                 }
             } catch (IOException e) {
@@ -697,7 +715,6 @@ public class MainActivity extends AppCompatActivity implements BillingProcessor.
         @Override
         protected Void doInBackground(Void... voids) {
             List<Solve> solveList = new ArrayList<>();
-            int imports = 0;
 
             try {
 
@@ -718,32 +735,41 @@ public class MainActivity extends AppCompatActivity implements BillingProcessor.
                             parseErrors++;
                         }
                     }
-
                 }
 
                 if (tag.equals("import_external")) {
+                    final long now = DateTime.now().getMillis();
 
                     while ((line = csvReader.readNext()) != null) {
-                        if (line.length <= 3) {
+                        if (line.length <= 4) {
                             try {
                                 Log.d("IMPORTING EXTERNAL", "time: " + line[0]);
 
                                 int time = PuzzleUtils.parseTime(line[0]);
                                 String scramble = "";
-                                long date = DateTime.now().getMillis();
-                                ;
+                                long date = now;
+                                int penalty = PuzzleUtils.NO_PENALTY;
+
                                 if (line.length >= 2) {
                                     scramble = line[1];
                                 }
-                                if (line.length == 3) {
+                                if (line.length >= 3) {
                                     try {
                                         date = DateTime.parse(line[2]).getMillis();
                                     } catch (Exception e) {
+                                        // "date" remains equal to "now".
                                         e.printStackTrace();
                                     }
                                 }
+                                // Optional fourth field (index 3) may contain "DNF". If it is
+                                // something else, ignore it.
+                                if (line.length >= 4 && "DNF".equals(line[3])) {
+                                    penalty = PuzzleUtils.PENALTY_DNF;
+                                }
 
-                                solveList.add(new Solve(time, exportImportPuzzle, exportImportCategory, date, scramble, PuzzleUtils.NO_PENALTY, "", true));
+                                solveList.add(new Solve(
+                                        time, exportImportPuzzle, exportImportCategory,
+                                        date, scramble, penalty, "", true));
                             } catch (Exception e) {
                                 parseErrors++;
                             }
@@ -751,21 +777,16 @@ public class MainActivity extends AppCompatActivity implements BillingProcessor.
                             parseErrors++;
                         }
                     }
-
                 }
 
-                publishProgress(imports, solveList.size());
-
-                for (Solve solve : solveList) {
-                    if (! handler.solveExists(solve)) {
-                        handler.addSolve(solve);
-                        successes++;
-                    } else
-                        duplicates++;
-                    imports++;
-                    publishProgress(imports);
-                }
-
+                // Perform a bulk insertion of the solves.
+                successes = handler.addSolves(solveList, new ProgressListener() {
+                            @Override
+                            public void onProgress(int numCompleted, int total) {
+                                publishProgress(numCompleted, total);
+                            }
+                        });
+                duplicates = solveList.size() - successes;
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/app/src/main/java/com/aricneto/twistytimer/adapter/TimeCursorAdapter.java
+++ b/app/src/main/java/com/aricneto/twistytimer/adapter/TimeCursorAdapter.java
@@ -109,7 +109,7 @@ public class TimeCursorAdapter extends CursorRecyclerAdapter<RecyclerView.ViewHo
 
     public void deleteAllSelected() {
         DatabaseHandler handler = new DatabaseHandler(mContext);
-        handler.deleteAllFromList(selectedItems);
+        handler.deleteSolvesByID(selectedItems, null); // Ignore progress updates.
         handler.closeDB();
         resetList();
     }

--- a/app/src/main/java/com/aricneto/twistytimer/fragment/dialog/TimeDialog.java
+++ b/app/src/main/java/com/aricneto/twistytimer/fragment/dialog/TimeDialog.java
@@ -75,7 +75,7 @@ public class TimeDialog extends DialogFragment {
                                     getContext().startActivity(shareIntent);
                                     break;
                                 case R.id.remove:
-                                    handler.deleteFromId(mId);
+                                    handler.deleteSolveByID(mId);
                                     updateList();
                                     break;
                                 case R.id.history_to:


### PR DESCRIPTION
(This request is a bit tentative. Feel free to suggest alternative ways of
supporting "DNF" in the text format file. Also, if you want to accept my
other pull request first, I can merge it from "master" to this topic branch
and resubmit this pull request.)

Added a trailing, optional "DNF" field to the supported format of simple
text files used for import/export. The inability to export "DNF" solves
made the text format useless when I tried exporting 1,000+ solves to
text (on a real device) and then importing them (on an emulator). All of
the statistics were a mess, as DNF solves were treated as normal solves
with ridiculously high and low times, which mess up the averages, too.

Perhaps the "DNF" field in the text file should replace the first time
field (and the time can then be recorded as 0.00 with the penalty flag
set to DNF), but it is added as a fourth field in this tentative
implementation. The importing operation is still compatible with the
older format. If an old version of the app attempts to import the new
text format with "DNF" solves, those solves will be ignored and reported
in the count of errors. In terms of the integrity of the statistics,
this is probably no better or worse than importing DNF solves as
successful solves, which was the old behaviour.

The "PuzzleUtils.parseTime" method was very slow. On importing 1,077
puzzle results from a text file (on an emulator), it took 8.3 seconds to
parse the data and then 1-2 minutes to insert it into the database. Of
the 8.3 seconds spent parsing, 8.0 seconds were down to "parseTime". I
measured the performance of the new version and it is 217 times faster!
Parsing 1,077 lines now takes about 0.3 s in total (before the database
insertions start). This avoids a long time looking at the progress bar
sitting at zero before progress starts being reported for the database
insertions.

The 1-2 minutes to perform the database insert has been reduced to about
2 seconds. The inserts are now wrapped in a single database transaction,
so there is no journal file overhead after each insertion. The bulk
delete operations now work the same way. Progress reporting is
integrated into the new database operations. It is not used for the
deletes, but it could be in the future if required.
