### PR TITLE
Ignore branch name

### DIFF
--- a/app/src/main/java/com/aricneto/twistytimer/activity/MainActivity.java
+++ b/app/src/main/java/com/aricneto/twistytimer/activity/MainActivity.java
@@ -649,13 +649,13 @@ public class MainActivity extends AppCompatActivity
     public void onFileSelection(@NonNull FileChooserDialog dialog, @NonNull File file) {
         // This "relay" scheme ensures that this activity is not embroiled in the gory details of
         // what the "destinationFrag" wanted with the file.
-        final Fragment destinationFrag = fragmentManager.findFragmentByTag(dialog.getTag());
+        final Fragment destinationFrag = fragmentManager.findFragmentByTag(FRAG_TAG_EXIM_DIALOG);
 
         if (destinationFrag instanceof FileChooserDialog.FileCallback) {
             ((FileChooserDialog.FileCallback) destinationFrag).onFileSelection(dialog, file);
         } else {
             // This is not expected unless there is a bug to be fixed.
-            Log.e(TAG, "onFileSelection(): Unknown or incompatible fragment: " + dialog.getTag());
+            Log.e(TAG, "onFileSelection(): Unknown or incompatible fragment: " + destinationFrag.getTag());
         }
     }
 

--- a/app/src/main/java/com/aricneto/twistytimer/fragment/dialog/ExportImportDialog.java
+++ b/app/src/main/java/com/aricneto/twistytimer/fragment/dialog/ExportImportDialog.java
@@ -55,6 +55,11 @@ public class ExportImportDialog extends DialogFragment
      */
     public static final int EXIM_FORMAT_BACKUP = 2;
 
+    /**
+     * The tag for the {@code FileChooserDialog} called by this fragment
+     */
+    public static final String FRAG_TAG_EXIM_FILECHOOSER = "exim_file_chooser";
+
 
     /**
      * A call-back interface that supports interaction between the import/export dialogs, file chooser
@@ -159,7 +164,7 @@ public class ExportImportDialog extends DialogFragment
                     // be relayed back to this dialog fragment.
                     new FileChooserDialog.Builder(getExImActivity())
                             .chooseButton(R.string.action_choose)
-                            .tag(ExportImportDialog.this.getTag())
+                            .tag(FRAG_TAG_EXIM_FILECHOOSER)
                             .show();
                     break;
 
@@ -181,7 +186,7 @@ public class ExportImportDialog extends DialogFragment
                                                     @NonNull DialogAction which) {
                                     new FileChooserDialog.Builder(getExImActivity())
                                             .chooseButton(R.string.action_choose)
-                                            .tag(ExportImportDialog.this.getTag())
+                                            .tag(FRAG_TAG_EXIM_FILECHOOSER)
                                             .show();
                                 }
                             })


### PR DESCRIPTION
> Fixed bug where times were not being imported after choosing a file.
	> The onFileSelection callback on MainActivity was trying to get the ExportImportDialog that called FileChooserDialog by using getTag, but both the ExportImportDialog and FileChooserDialog have the same tag (export_import_dialog). The fix was to have ExportImportDialog create a FileChooserDialog with a different tag.
> Temporarily changed the way the AverageCalculator handles an exception in the addTime function.
	> See the FIXME note for reasoning.