### PR TITLE
Fix add of empty comment

### DIFF
--- a/app/src/main/java/com/aricneto/twistytimer/fragment/TimerFragment.java
+++ b/app/src/main/java/com/aricneto/twistytimer/fragment/TimerFragment.java
@@ -342,12 +342,14 @@ public class TimerFragment extends BaseFragment
                                 @Override
                                 public void onInput(@NonNull MaterialDialog dialog,
                                                     CharSequence input) {
-                                    currentSolve.setComment(input.toString());
-                                    dbHandler.updateSolve(currentSolve);
-                                    // NOTE: At present, the Statistics and ChartStatistics do not
-                                    // need to know about changes to a comment, so a notification
-                                    // of this change does not need to be broadcast.
-                                    Toast.makeText(getContext(), getString(R.string.added_comment), Toast.LENGTH_SHORT).show();
+                                    if (input.toString().trim().length() != 0) {
+                                        currentSolve.setComment(input.toString());
+                                        dbHandler.updateSolve(currentSolve);
+                                        // NOTE: At present, the Statistics and ChartStatistics do not
+                                        // need to know about changes to a comment, so a notification
+                                        // of this change does not need to be broadcast.
+                                        Toast.makeText(getContext(), getString(R.string.added_comment), Toast.LENGTH_SHORT).show();
+                                    }   
                                     hideButtons(false, true);
                                 }
                             })

--- a/app/src/main/java/com/aricneto/twistytimer/fragment/dialog/TimeDialog.java
+++ b/app/src/main/java/com/aricneto/twistytimer/fragment/dialog/TimeDialog.java
@@ -136,10 +136,12 @@ public class TimeDialog extends DialogFragment {
                             .input("", solve.getComment(), new MaterialDialog.InputCallback() {
                                 @Override
                                 public void onInput(MaterialDialog dialog, CharSequence input) {
-                                    solve.setComment(input.toString());
-                                    dbHandler.updateSolve(solve);
-                                    Toast.makeText(getContext(), getString(R.string.added_comment), Toast.LENGTH_SHORT).show();
-                                    updateList();
+                                    if (input.toString().trim().length() != 0) {
+                                        solve.setComment(input.toString());
+                                        dbHandler.updateSolve(solve);
+                                        Toast.makeText(getContext(), getString(R.string.added_comment), Toast.LENGTH_SHORT).show();
+                                        updateList();
+                                    }
                                 }
                             })
                             .inputType(InputType.TYPE_TEXT_FLAG_MULTI_LINE)


### PR DESCRIPTION
Should fix #92. Comments will be added only if non-empty.
Comments consisting of only whitespaces, newlines and/or tabs are considered empty.
If an empty comment is added nothing will appear (it would be like if you had clicked on CANCEL). Do you think some error message should appear instead?