### PR TITLE
New option on AlgListFragment: Filter by Progress

### DIFF
--- a/app/src/main/java/com/aricneto/twistytimer/database/AlgTaskLoader.java
+++ b/app/src/main/java/com/aricneto/twistytimer/database/AlgTaskLoader.java
@@ -8,17 +8,18 @@ import com.aricneto.twistytimer.TwistyTimer;
 public class AlgTaskLoader extends CursorLoader {
 
     String subset;
-
-    public AlgTaskLoader(String subset) {
+    int progress_filter = 100;
+    public AlgTaskLoader(String subset, int progress_filter) {
         super(TwistyTimer.getAppContext());
         this.subset = subset;
+        this.progress_filter = progress_filter;
     }
 
     @Override
     public Cursor loadInBackground() {
         return TwistyTimer.getReadableDB().query(
                 DatabaseHandler.TABLE_ALGS, null,
-                DatabaseHandler.KEY_SUBSET + "=?",
-                new String[] { subset }, null, null, null, null);
+                DatabaseHandler.KEY_SUBSET + "=? AND " + DatabaseHandler.KEY_PROGRESS +" <=?",
+                new String[] { subset, Integer.toString(progress_filter) }, null, null, null, null);
     }
 }

--- a/app/src/main/java/com/aricneto/twistytimer/fragment/TimerFragmentMain.java
+++ b/app/src/main/java/com/aricneto/twistytimer/fragment/TimerFragmentMain.java
@@ -135,6 +135,7 @@ public class TimerFragmentMain extends BaseFragment implements OnBackPressedInFr
 
     @BindView(R.id.nav_button_settings) View      navButtonSettings;
     @BindView(R.id.nav_button_category) View      navButtonCategory;
+    @BindView(R.id.nav_button_filter) View      navButtonFilter;
     @BindView(R.id.nav_button_history) ImageView navButtonHistory;
 
     @BindView(R.id.puzzleCategory) TextView puzzleCategoryText;
@@ -420,6 +421,7 @@ public class TimerFragmentMain extends BaseFragment implements OnBackPressedInFr
         navButtonCategory.setOnClickListener(clickListener);
         navButtonHistory.setOnClickListener(clickListener);
         navButtonSettings.setOnClickListener(clickListener);
+        navButtonFilter.setVisibility(View.GONE);
 
         if (savedInstanceState == null) {
             // Remember last used puzzle

--- a/app/src/main/java/com/aricneto/twistytimer/fragment/dialog/BottomSheetTrainerDialog.java
+++ b/app/src/main/java/com/aricneto/twistytimer/fragment/dialog/BottomSheetTrainerDialog.java
@@ -173,7 +173,7 @@ public class BottomSheetTrainerDialog extends BottomSheetDialogFragment implemen
 
     @Override
     public Loader<Cursor> onCreateLoader(int i, Bundle bundle) {
-        return new AlgTaskLoader(currentSubset.name());
+        return new AlgTaskLoader(currentSubset.name(), 100);
     }
 
     @Override

--- a/app/src/main/res/drawable/background_gradient.xml
+++ b/app/src/main/res/drawable/background_gradient.xml
@@ -17,7 +17,7 @@
 
         <bitmap
             android:alpha="0.1"
-            android:src="@drawable/twisty_pattern"
+            android:src="@drawable/icon_launch"
             android:tileMode="repeat" />
 
     </item>

--- a/app/src/main/res/drawable/ic_outline_filter_24.xml
+++ b/app/src/main/res/drawable/ic_outline_filter_24.xml
@@ -1,0 +1,7 @@
+<vector android:height="100dp" android:viewportHeight="111.36"
+    android:viewportWidth="111.36" android:width="100dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#00000000"
+        android:pathData="M23.235,17.566 L47.011,56.495 47.138,94.119 66.88,72.761V55.929L90.863,17.99 23.235,17.566c3.247,-0.017 7.773,0.094 11.021,0.094"
+        android:strokeColor="#ffffff" android:strokeLineCap="butt"
+        android:strokeLineJoin="round" android:strokeWidth="4.53941"/>
+</vector>

--- a/app/src/main/res/layout/main_actionbar.xml
+++ b/app/src/main/res/layout/main_actionbar.xml
@@ -91,6 +91,22 @@
             app:srcCompat="@drawable/ic_outline_category_24" />
 
         <ImageView
+            android:id="@+id/nav_button_filter"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_alignParentRight="true"
+            android:layout_centerVertical="true"
+            android:layout_marginEnd="8dp"
+            android:layout_marginRight="8dp"
+            android:alpha="1"
+            android:background="?selectableItemBackgroundBorderless"
+            android:clickable="true"
+            android:focusable="true"
+            android:padding="8dp"
+            android:tint="?colorActionBarText"
+            app:srcCompat="@drawable/ic_outline_filter_24" />
+        <ImageView
             android:id="@+id/nav_button_history"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/menu/menu_list_more.xml
+++ b/app/src/main/res/menu/menu_list_more.xml
@@ -7,22 +7,18 @@
 
     <item
         android:id="@+id/sort"
-        android:icon="@drawable/ic_filter_list_24dp"
         android:title="@string/list_sort_title">
         <menu>
             <item
                 android:id="@+id/sort_time"
-                android:icon="@drawable/ic_alarm_24dp"
                 android:title="@string/list_sort_time">
 
                 <menu>
                     <item
                         android:id="@+id/sort_asc"
-                        android:icon="@drawable/ic_arrow_upward_24dp"
                         android:title="@string/list_sort_ascending" />
                     <item
                         android:id="@+id/sort_desc"
-                        android:icon="@drawable/ic_arrow_downward_24dp"
                         android:title="@string/list_sort_descending" />
                 </menu>
             </item>
@@ -33,11 +29,9 @@
                 <menu>
                     <item
                         android:id="@+id/sort_ascd"
-                        android:icon="@drawable/ic_arrow_upward_24dp"
                         android:title="@string/list_sort_ascending" />
                     <item
                         android:id="@+id/sort_descd"
-                        android:icon="@drawable/ic_arrow_downward_24dp"
                         android:title="@string/list_sort_descending" />
                 </menu>
             </item>

--- a/app/src/main/res/menu/menu_sort_items.xml
+++ b/app/src/main/res/menu/menu_sort_items.xml
@@ -2,7 +2,6 @@
     xmlns:tools="http://schemas.android.com/tools">
     <item
         android:id="@+id/sort_time"
-        android:icon="@drawable/ic_alarm_24dp"
         android:title="@string/list_sort_time" />
     <item
         android:id="@+id/sort_date"

--- a/app/src/main/res/menu/menu_sort_options.xml
+++ b/app/src/main/res/menu/menu_sort_options.xml
@@ -2,10 +2,8 @@
     xmlns:tools="http://schemas.android.com/tools">
     <item
         android:id="@+id/sort_asc"
-        android:icon="@drawable/ic_arrow_upward_24dp"
         android:title="@string/list_sort_ascending" />
     <item
         android:id="@+id/sort_desc"
-        android:icon="@drawable/ic_arrow_downward_24dp"
         android:title="@string/list_sort_descending" />
 </menu>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@mipmap/ic_launcher_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@mipmap/ic_launcher_background"/>
+    
     <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -58,6 +58,7 @@
     <string name="dialog_revert_content_confirmation">Restaurar os algoritmos deste caso de volta para o padrão?</string>
     <string name="dialog_revert_title_confirmation">Restaurar algoritmos</string>
     <string name="dialog_set_progress">Atualizar progresso</string>
+    <string name="dialog_filter_progress">Filtrar por progresso</string>
     <string name="drawer_about">Sobre e feedback</string>
     <string name="drawer_title_changeColorScheme">Cores do cubo</string>
     <string name="drawer_title_changeTheme">Tema do app</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,6 +87,7 @@
     <string name="dialog_revert_content_confirmation">Reset the algorithms for this case back to the default?</string>
     <string name="dialog_revert_title_confirmation">Reset algorithms</string>
     <string name="dialog_set_progress">Set progress</string>
+    <string name="dialog_filter_progress">Filter by progress</string>
 
     <string name="donation_tier1" translatable="false">1 USD</string>
     <string name="donation_tier2" translatable="false">2 USD</string>

--- a/ic_nav_bar_filter.svg
+++ b/ic_nav_bar_filter.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg824"
+   width="111.36"
+   height="111.36"
+   viewBox="0 0 111.36 111.36"
+   sodipodi:docname="ic_nav_bar_filter.svg"
+   inkscape:version="1.1 (c68e22c387, 2021-05-23)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs828" />
+  <sodipodi:namedview
+     id="namedview826"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="3.5964439"
+     inkscape:cx="51.161649"
+     inkscape:cy="55.749514"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g830" />
+  <g
+     inkscape:groupmode="layer"
+     inkscape:label="Image"
+     id="g830">
+    <path
+       style="fill:#000000;stroke-width:0.32"
+       id="path1106"
+       d="" />
+    <path
+       style="fill:#000000;stroke-width:0.32"
+       id="path1086"
+       d="" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:4.53941;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill"
+       d="M 23.23499,17.565792 47.011292,56.494838 47.137844,94.119492 66.879857,72.761137 V 55.929054 L 90.863088,17.99013 23.23499,17.565792 c 3.246801,-0.01706 7.772717,0.09428 11.020617,0.09428"
+       id="path1267"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+</svg>


### PR DESCRIPTION
New button on the navbar of Algorithms page: Filter by Progress, it opens an AppCompatSeekBar with default 100% progress. Reload the alg list on progress update with the selected progress. Only algorithms with KEY_PROGRESS<=progress_filter will be fetched from the TwistyTimer.getReadableDB.

Why? to easily see only the cases which I(we) still hadn't learned.

Unfortunately I couldn't import the solves from the backup I saved with the original app, but as it is a separate app, no loss of data happened. I also would've liked to import the algorithms progresses.